### PR TITLE
bumps excluding FluentValidation

### DIFF
--- a/src/Atlas.Client/Atlas.Client.csproj
+++ b/src/Atlas.Client/Atlas.Client.csproj
@@ -13,16 +13,16 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="8.6.2" />
-    <PackageReference Include="Markdig" Version="0.20.0" />
+    <PackageReference Include="Markdig" Version="0.21.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="3.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.7" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="3.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="3.1.8" />
     <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />
-    <PackageReference Include="Tewr.Blazor.FileReader" Version="2.0.0.20200" />
+    <PackageReference Include="Tewr.Blazor.FileReader" Version="2.0.0.20242" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atlas.Data/Atlas.Data.csproj
+++ b/src/Atlas.Data/Atlas.Data.csproj
@@ -6,13 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.20.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="3.1.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.6" />
+    <PackageReference Include="Markdig" Version="0.21.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="3.1.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Atlas.Models/Atlas.Models.csproj
+++ b/src/Atlas.Models/Atlas.Models.csproj
@@ -7,9 +7,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="8.6.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="3.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Forms" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.8" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/Atlas.Server/Atlas.Server.csproj
+++ b/src/Atlas.Server/Atlas.Server.csproj
@@ -18,10 +18,10 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="8.6.2" />
     <PackageReference Include="LucaBriguglia.Docs" Version="1.2.0" />
-    <PackageReference Include="Markdig" Version="0.20.0" />
+    <PackageReference Include="Markdig" Version="0.21.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="3.2.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
-    <PackageReference Include="Scrutor" Version="3.2.1" />
+    <PackageReference Include="Scrutor" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,12 +32,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="3.1.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="3.1.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/test/Atlas.Data.Tests/Atlas.Data.Tests.csproj
+++ b/test/Atlas.Data.Tests/Atlas.Data.Tests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.13.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="AutoFixture" Version="4.14.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">

--- a/test/Atlas.Domain.Tests/Atlas.Domain.Tests.csproj
+++ b/test/Atlas.Domain.Tests/Atlas.Domain.Tests.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="AutoFixture" Version="4.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.14.5" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">


### PR DESCRIPTION
left out breaking changes with fluentvalidation framework (https://docs.fluentvalidation.net/en/latest/upgrading-to-9.html)

fwiw i think the changes to `FluentValidationValidator.cs` should be as follows:

but maybe you're in 2 minds whether it's worth using...

```
using Microsoft.AspNetCore.Components;
using FluentValidation;
using FluentValidation.Results;
using Microsoft.AspNetCore.Components.Forms;
using System;
using System.Threading.Tasks;


namespace Atlas.Client.Components
{
    /// <summary>
    /// https://blazor-university.com/forms/writing-custom-validation/
    /// </summary>
    public class FluentValidationValidator : ComponentBase
    {

        private IValidationContext _fluentValidationContext;

        /// <summary>
        /// The EditContext cascaded to us from the EditForm component.
        /// This changes whenever EditForm.Model changes
        /// </summary>
        [CascadingParameter]
        private EditContext EditContext { get; set; }

        [Parameter]
        public Type ValidatorType { get; set; }

        // Holds an instance to perform our actual validation
        private IValidator _validator;

        // This is where we register our validation errors for Blazor to pick up
        // in the UI. Like EditContext, this instance should be discarded when
        // EditForm.Model changes (for us, that's when EditContext changes).
        private ValidationMessageStore _validationMessageStore;

        // Inject the service provider so we can create our IValidator instances
        [Inject]
        private IServiceProvider ServiceProvider { get; set; }

        /// <summary>
        /// Executed when a parameter or cascading parameter changes. We need
        /// to know if the EditContext has changed as a consequence of
        /// EditForm.Model changing.
        /// See http://blazor-university.com/components/component-lifecycles/ (component lifecycles).
        /// </summary>
        public override async Task SetParametersAsync(ParameterView parameters)
        {
            // Keep a reference to the original values so we can check if they have changed
            EditContext previousEditContext = EditContext;
            Type previousValidatorType = ValidatorType;

            await base.SetParametersAsync(parameters);

            if (EditContext == null)
                throw new NullReferenceException($"{nameof(FluentValidationValidator)} must be placed within an {nameof(EditForm)}");

            if (ValidatorType == null)
                throw new NullReferenceException($"{nameof(ValidatorType)} must be specified.");

            if (!typeof(IValidator).IsAssignableFrom(ValidatorType))
                throw new ArgumentException($"{ValidatorType.Name} must implement {typeof(IValidator).FullName}");

            if (ValidatorType != previousValidatorType)
                ValidatorTypeChanged();

            // If the EditForm.Model changes then we get a new EditContext
            // and need to hook it up
            if (EditContext != previousEditContext)
                EditContextChanged();
        }

        /// <summary>
        /// We create a new instance of the validator whenever ValidatorType changes.
        /// </summary>
        private void ValidatorTypeChanged()
        {
            _validator = (IValidator)ServiceProvider.GetService(ValidatorType);
        }

        /// <summary>
        /// We trigger this when SetParametersAsync is executed and results in us having a
        /// new EditContext.
        /// </summary>
        void EditContextChanged()
        {
            System.Diagnostics.Debug.WriteLine("EditContext has changed");

            // We need this to store our validation errors
            // Whenever we get a new EditContext (because EditForm.Model has changed)
            // we also need to discard our old message store and create a new one
            _validationMessageStore = new ValidationMessageStore(EditContext);
            System.Diagnostics.Debug.WriteLine("New ValidationMessageStore created");

            // Observe any changes to the EditForm.Model object
            HookUpEditContextEvents();
        }

        private void HookUpEditContextEvents()
        {
            // We need to know when to validate the whole object, this
            // is triggered when the EditForm is submitted
            EditContext.OnValidationRequested += ValidationRequested;

            // We need to know when to validate an individual property, this
            // is triggered when the user edits something
            EditContext.OnFieldChanged += FieldChanged;

            System.Diagnostics.Debug.WriteLine("Hooked up EditContext events (OnValidationRequested and OnFieldChanged)");
        }

        async void ValidationRequested(object sender, ValidationRequestedEventArgs args)
        {
            System.Diagnostics.Debug.WriteLine("OnValidationRequested triggered: Validating whole object");

            // Clear all errors from a previous validation
            _validationMessageStore.Clear();
            
            // Tell FluentValidation to validate the object
            ValidationResult result = await _validator.ValidateAsync(_fluentValidationContext);

            // Now add the results to the ValidationMessageStore we created
            AddValidationResult(EditContext.Model, result);
        }

        async void FieldChanged(object sender, FieldChangedEventArgs args)
        {
            System.Diagnostics.Debug.WriteLine($"OnFieldChanged triggered: Validating a single property named {args.FieldIdentifier.FieldName}" +
                $" on class {args.FieldIdentifier.Model.GetType().Name}");

            // Create a FieldIdentifier to identify which property
            // of an an object has been modified
            FieldIdentifier fieldIdentifier = args.FieldIdentifier;

            // Make sure we clear out errors from a previous validation
            // only for this Object+Property
            _validationMessageStore.Clear(fieldIdentifier);

            // FluentValidation specific, we need to tell it to only validate
            // a specific property
            var propertiesToValidate = new string[] { fieldIdentifier.FieldName };

            _fluentValidationContext =
                new ValidationContext<object>(
                    instanceToValidate: fieldIdentifier.Model,
                    propertyChain: new FluentValidation.Internal.PropertyChain(),
                    validatorSelector: new FluentValidation.Internal.MemberNameValidatorSelector(propertiesToValidate)
                );

            // Tell FluentValidation to validate the specified property on the object that was edited
            ValidationResult result = await _validator.ValidateAsync(_fluentValidationContext);

            // Now add the results to the ValidationMessageStore we created
            AddValidationResult(fieldIdentifier.Model, result);
        }

        /// <summary>
        /// Adds all of the errors from the Fluent Validator to the ValidationMessageStore
        /// we created when the EditContext changed
        /// </summary>
        void AddValidationResult(object model, ValidationResult validationResult)
        {
            foreach (ValidationFailure error in validationResult.Errors)
            {
                var fieldIdentifier = new FieldIdentifier(model, error.PropertyName);
                _validationMessageStore.Add(fieldIdentifier, error.ErrorMessage);
            }
            EditContext.NotifyValidationStateChanged();
        }
    }
}

```



